### PR TITLE
Don't cache Redirects fixes #13

### DIFF
--- a/src/Flatten/EventHandler.php
+++ b/src/Flatten/EventHandler.php
@@ -50,6 +50,11 @@ class EventHandler
 	 */
 	public function onApplicationDone(Response $response = null)
 	{
+		// Do not cache a redirect Responses
+		if(!is_null($response) && $response->isRedirection()){
+			return;
+		}
+		
 		// Get the Response's or the buffer's contents
 		$content = $response ? $response->getContent() : ob_end_flush();
 


### PR DESCRIPTION
If `onApplicationDone` was passed a `Response` check to see if this response was a redirection. And if so do not cache it.
http://api.symfony.com/2.0/Symfony/Component/HttpFoundation/Response.html
