### PR TITLE
Do not cache error pages

### DIFF
--- a/src/Flatten/EventHandler.php
+++ b/src/Flatten/EventHandler.php
@@ -54,6 +54,21 @@ class EventHandler
 		if(!is_null($response) and $response->isRedirection()) {
 			return false;
 		}
+		
+		// Do not cache 404 error pages
+		if(!is_null($response) and $response->isNotFound()) {
+            		return false;
+		}
+
+		// Do not cache server errors
+        	if(!is_null($response) and $response->isServerError()) {
+            		return false;
+	        }
+
+	        // Do not cache forbidden pages
+	        if(!is_null($response) and $response->isForbidden()) {
+	            return false;
+	        }
 
 		// Get the Response's or the buffer's contents
 		$content = $response ? $response->getContent() : ob_end_flush();


### PR DESCRIPTION
Since we're loosing the HTTP status when caching error pages. Also, errors shouldn't be cached. Solves issue #20
