### PR TITLE
Pass view arguments to the internal function of cache section.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+1.1.0 - 2015-XX-XX
+------------------
+
+### Added
+
+- Added ability to disable cache timestamp
+
 1.0.2 - 2015-09-09
 ------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
 ### Added
 
 - Added ability to disable cache timestamp
+- Added ability to minify output before caching it
 
 1.0.2 - 2015-09-09
 ------------------

--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,15 @@
         "illuminate/cache": "5.0.*|5.1.*",
         "illuminate/config": "5.0.*|5.1.*",
         "illuminate/http": "5.0.*|5.1.*",
-        "illuminate/contracts": "5.0.*|5.1.*"
+        "illuminate/contracts": "5.0.*|5.1.*",
+        "mrclay/minify": "^2.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",
         "mockery/mockery": "^0.9.4",
         "illuminate/view": "5.0.*|5.1.*",
-        "fabpot/php-cs-fixer": "^1.10"
+        "fabpot/php-cs-fixer": "^1.10",
+        "symfony/var-dumper": "^2.7"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-develop": "1.0-dev"
+            "dev-develop": "1.1-dev"
         }
     }
 }

--- a/config/flatten.php
+++ b/config/flatten.php
@@ -27,10 +27,6 @@ return [
     // Cache variables
     ////////////////////////////////////////////////////////////////////
 
-    // Whether to append a timestamp comment on cached pages
-    // eg. <!-- Cached on 2015-09-09 01:01:01 -->
-    'timestamp' => true,
-
     // The default period during which a cached page should be kept (in minutes)
     // 0 means the page never gets refreshed by itself
     'lifetime' => 0,
@@ -38,4 +34,15 @@ return [
     // An array of string or variables to add to the salt being used
     // to differentiate pages
     'saltshaker' => [],
+
+    // Cache output
+    //////////////////////////////////////////////////////////////////////
+
+    // Whether to append a timestamp comment on cached pages
+    // eg. <!-- Cached on 2015-09-09 01:01:01 -->
+    'timestamp' => true,
+
+    // Whether to minify the HTML before caching it
+    'minify' => false,
+
 ];

--- a/config/flatten.php
+++ b/config/flatten.php
@@ -27,6 +27,10 @@ return [
     // Cache variables
     ////////////////////////////////////////////////////////////////////
 
+    // Whether to append a timestamp comment on cached pages
+    // eg. <!-- Cached on 2015-09-09 01:01:01 -->
+    'timestamp' => true,
+
     // The default period during which a cached page should be kept (in minutes)
     // 0 means the page never gets refreshed by itself
     'lifetime' => 0,

--- a/src/CacheHandler.php
+++ b/src/CacheHandler.php
@@ -82,7 +82,9 @@ class CacheHandler
         $this->app['flatten.storage']->set('cached', $cached);
 
         // Add timestamp to cache
-        $content .= PHP_EOL.'<!-- cached on '.date('Y-m-d H:i:s').' -->';
+        if ($this->app['config']->get('flatten.timestamp')) {
+            $content .= PHP_EOL.'<!-- cached on '.date('Y-m-d H:i:s').' -->';
+        }
 
         return $this->app['cache']->put(
             $this->hash, $content, $this->getLifetime()

--- a/src/Templating.php
+++ b/src/Templating.php
@@ -53,7 +53,9 @@ class Templating
         $blade->directive('cache', function($expression) {
             $expression = rtrim($expression, ')');
 
-           return '<?php echo Flatten\\Facades\\Flatten::section' .$expression. ', function() { ?>';
+           return '<?php \$viewArgs = get_defined_vars();'
+		.'echo Flatten\\Facades\\Flatten::section' .$expression.
+		', function() use(\$viewArgs) { extract(\$viewArgs) ?>';
         });
 
         $blade->directive('endcache', function() {

--- a/tests/CacheHandlerTest.php
+++ b/tests/CacheHandlerTest.php
@@ -121,4 +121,49 @@ class CacheHandlerTest extends FlattenTestCase
         $this->cache->flushAction('MaintainersController@maintainer', 'anahkiasen');
         $this->assertFalse($this->app['cache']->has('GET-/maintainer/anahkiasen'));
     }
+
+    public function testCanMinifyHtmlContent()
+    {
+        $this->app['config']->set('flatten.minify', true);
+
+        $content = <<<EOF
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Document</title>
+    <style>
+        .foo {
+            background: red;
+        }
+    </style>
+</head>
+<body>
+    <main>
+        <pre>
+            var foo = '
+                bar';
+        </pre>
+    </main>
+
+    <script>
+        var foo = 'foo';
+        var bar = 'bar';
+    </script>
+</body>
+</html>
+EOF;
+
+        $expected =
+            '<!doctype html><html
+lang="en"><head><meta
+charset="UTF-8"><title>Document</title><style>.foo{background:red}</style></head><body>
+<main><pre>
+            var foo = \'
+                bar\';
+        </pre></main> <script>var foo=\'foo\',bar=\'bar\'</script> </body></html>';
+
+        $this->cache->storeCache($content);
+        $this->assertEquals($expected, $this->cache->getCache());
+    }
 }

--- a/tests/CacheHandlerTest.php
+++ b/tests/CacheHandlerTest.php
@@ -26,6 +26,15 @@ class CacheHandlerTest extends FlattenTestCase
         $this->assertContains('foobar', $this->cache->getCache());
     }
 
+    public function testCanDisableTimestamp()
+    {
+        $this->config->set('flatten.timestamp', false);
+
+        $this->cache->storeCache('foobar');
+
+        $this->assertEquals('foobar', $this->app['cache']->get($this->cache->getHash()));
+    }
+
     public function testCanFlushSpecificPatterns()
     {
         $this->mockRequest('/maintainers');


### PR DESCRIPTION
For such case in Laravel when we create view with arguments, such us:

    View::make('layouts.index')->with('categories', $categories)

have defined `layouts/index.blade.php` like this:

    <html><body>
        <h1>My page title</h1>
        @include('partials.menu')
        <section id="page-content> ... </section>
    </body></html>

and want to use `$categories` in `menu` partial:

    @cache('menu', 10)
    <ul>
    @foreach ($categories as $category)
        <li>{{ $category['name'] }}</li>
    @endforeach
    </ul>
    @endcache

the `index` view didn't pass it's arguments to the `menu` partial so the commit fixes it. Not sure if it's the best way but it sure works for me.