### PR TITLE
Pass view arguments to the internal function of cache section

### DIFF
--- a/src/Templating.php
+++ b/src/Templating.php
@@ -53,7 +53,9 @@ class Templating
         $blade->directive('cache', function($expression) {
             $expression = rtrim($expression, ')');
 
-           return '<?php echo Flatten\\Facades\\Flatten::section' .$expression. ', function() { ?>';
+           return '<?php \$viewArgs = get_defined_vars();'
+		.'echo Flatten\\Facades\\Flatten::section' .$expression.
+		', function() use(\$viewArgs) { extract(\$viewArgs) ?>';
         });
 
         $blade->directive('endcache', function() {


### PR DESCRIPTION
(copied from #29)

For such case in Laravel when we create view with arguments, such us:

    View::make('layouts.index')->with('categories', $categories)

have defined `layouts/index.blade.php` like this:

    <html><body>
        <h1>My page title</h1>
        @include('partials.menu')
        <section id="page-content> ... </section>
    </body></html>

and want to use `$categories` in `menu` partial:

    @cache('menu', 10)
    <ul>
    @foreach ($categories as $category)
        <li>{{ $category['name'] }}</li>
    @endforeach
    </ul>
    @endcache

the `index` view didn't pass it's arguments to the `menu` partial so the commit fixes it. Not sure if it's the best way but it sure works for me.