### PR TITLE
Initial updates to support Laravel 5.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,18 +14,18 @@
         }
     ],
     "require": {
-        "illuminate/container": "5.0.*|5.1.*",
-        "illuminate/support": "5.0.*|5.1.*",
-        "illuminate/cache": "5.0.*|5.1.*",
-        "illuminate/config": "5.0.*|5.1.*",
-        "illuminate/http": "5.0.*|5.1.*",
-        "illuminate/contracts": "5.0.*|5.1.*",
+        "illuminate/container": "5.0.*|5.1.*|5.2.*",
+        "illuminate/support": "5.0.*|5.1.*|5.2.*",
+        "illuminate/cache": "5.0.*|5.1.*|5.2.*",
+        "illuminate/config": "5.0.*|5.1.*|5.2.*",
+        "illuminate/http": "5.0.*|5.1.*|5.2.*",
+        "illuminate/contracts": "5.0.*|5.1.*|5.2.*",
         "mrclay/minify": "^2.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",
         "mockery/mockery": "^0.9.4",
-        "illuminate/view": "5.0.*|5.1.*",
+        "illuminate/view": "5.0.*|5.1.*|5.2.*",
         "fabpot/php-cs-fixer": "^1.10",
         "symfony/var-dumper": "^2.7"
     },

--- a/src/FlattenMiddleware.php
+++ b/src/FlattenMiddleware.php
@@ -5,7 +5,7 @@ use Closure;
 use Illuminate\Contracts\Routing\Middleware;
 use Illuminate\Contracts\Routing\TerminableMiddleware;
 
-class FlattenMiddleware implements TerminableMiddleware
+class FlattenMiddleware
 {
     /**
      * @var Context

--- a/src/FlattenMiddleware.php
+++ b/src/FlattenMiddleware.php
@@ -2,8 +2,6 @@
 namespace Flatten;
 
 use Closure;
-use Illuminate\Contracts\Routing\Middleware;
-use Illuminate\Contracts\Routing\TerminableMiddleware;
 
 class FlattenMiddleware
 {


### PR DESCRIPTION
Composer.json was updated for the new version. Also, the "TerminableMiddleware" contract that the FlattenMiddleware class implemented apparently no longer exists, so I removed the reference to it.
